### PR TITLE
Avoid invoking Match twice in FindIndex and allow fetching index directly from Matcher

### DIFF
--- a/src/pkg/pcre/pcre.go
+++ b/src/pkg/pcre/pcre.go
@@ -375,7 +375,7 @@ func (m *Matcher) NamedPresent(group string) bool {
 // loc[0] is the start and loc[1] is the end.
 func (re *Regexp) FindIndex(bytes []byte, flags int) []int {
 	m := re.Matcher(bytes, flags)
-	if m.Match(bytes, flags) {
+	if m.Matches() {
 		return []int{int(m.ovector[0]), int(m.ovector[1])}
 	}
 	return nil

--- a/src/pkg/pcre/pcre.go
+++ b/src/pkg/pcre/pcre.go
@@ -337,6 +337,17 @@ func (m *Matcher) GroupString(group int) string {
 	return ""
 }
 
+// Index returns the start and end of the first match, if a previous
+// call to Matcher, MatcherString, Reset, ResetString, Match or
+// MatchString succeeded. loc[0] is the start and loc[1] is the end.
+func (m *Matcher) Index() []int {
+	if !m.Matches() {
+		return nil
+	}
+
+	return []int{int(m.ovector[0]), int(m.ovector[1])}
+}
+
 func (m *Matcher) name2index(name string) (group int) {
 	if m.re.ptr == nil {
 		panic("Matcher.Named: uninitialized")

--- a/src/pkg/pcre/pcre_test.go
+++ b/src/pkg/pcre/pcre_test.go
@@ -169,6 +169,23 @@ func TestNamed(t *testing.T) {
 	}
 }
 
+func TestMatcherIndex(t *testing.T) {
+	m := MustCompile("bcd", 0).Matcher([]byte("abcdef"), 0)
+	i := m.Index()
+	if i[0] != 1 {
+		t.Error("FindIndex start", i[0])
+	}
+	if i[1] != 4 {
+		t.Error("FindIndex end", i[1])
+	}
+
+	m = MustCompile("xyz", 0).Matcher([]byte("abcdef"), 0)
+	i = m.Index()
+	if i != nil {
+		t.Error("Index returned for non-match", i)
+	}
+}
+
 func TestFindIndex(t *testing.T) {
 	re := MustCompile("bcd", 0)
 	i := re.FindIndex([]byte("abcdef"), 0)


### PR DESCRIPTION
Creating a Matcher performs the match automatically and hence Matches() can be used to check success at a much lower cost.

Also, using FindIndex on a long stream will create a new Matches for each match. The second change helps avoid this and that also avoids an additional CGO call.
