### PR TITLE
Use pkg-config to locate libpcre and add ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+sudo: false
+addons:
+  apt:
+    packages:
+      - libpcre++-dev
+go:
+  - 1.3.3
+  - 1.4.1
+  - 1.4.2
+  - 1.4.3
+  - 1.5.1
+script:
+  - go test -v ./...

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,6 @@
 golang-pkg-pcre
 ===============
+[![Build Status](https://travis-ci.org/misakwa/golang-pkg-pcre.svg)](https://travis-ci.org/misakwa/golang-pkg-pcre)
 
 This is a Go language package providing Perl-Compatible RegularExpression
 support using libpcre++.  Install the package with the current Debian

--- a/src/pkg/pcre/pcre.go
+++ b/src/pkg/pcre/pcre.go
@@ -46,12 +46,9 @@
 // package and the flags defined below, see the PCRE documentation.
 package pcre
 
-/*
-#cgo LDFLAGS: -lpcre
-#cgo CFLAGS: -I/opt/local/include
-#include <pcre.h>
-#include <string.h>
-*/
+// #cgo pkg-config: libpcre
+// #include <pcre.h>
+// #include <string.h>
 import "C"
 
 import (


### PR DESCRIPTION
- Use pkg-config to locate libpcre and removes hard coded path
- Add .travis.yml and badge

This makes it easier to build on different environments and I also added a .travis.yml file as well as a badge. I have only enabled the badge on my fork. Once this is reviewed I can update it to point to it.
